### PR TITLE
Smarty version check fixed

### DIFF
--- a/src/renderer/AgaviSmartyRenderer.class.php
+++ b/src/renderer/AgaviSmartyRenderer.class.php
@@ -123,7 +123,7 @@ class AgaviSmartyRenderer extends AgaviRenderer implements AgaviIReusableRendere
 
 		$this->smarty = $this->createEngineInstance();
 		
-		$this->isSmarty2 = !defined("Smarty::SMARTY_VERSION") || !preg_match('#^Smarty.?3#', Smarty::SMARTY_VERSION, $matches);
+		$this->isSmarty2 = !defined("Smarty::SMARTY_VERSION");
 		
 		if($this->isSmarty2) {
 			$this->smarty->config_dir = AgaviConfig::get('core.config_dir');
@@ -208,5 +208,3 @@ class AgaviSmartyRenderer extends AgaviRenderer implements AgaviIReusableRendere
 		return $engine->fetch($resource, $this->isSmarty2 ? null : $data);
 	}
 }
-
-?>


### PR DESCRIPTION
Smarty 2 has no SMARTY_VERSION constant, so checking for its existence should be sufficient. The regex breaks current smarty versions, they are recognised as smarty 2 (version const changed from "Smarty-3._" to "3._").
